### PR TITLE
DOCS-5822 rm Anypoint Security link

### DIFF
--- a/modules/ROOT/pages/security.adoc
+++ b/modules/ROOT/pages/security.adoc
@@ -21,5 +21,4 @@ for member connections to both the Anypoint Platform and Salesforce systems.
 
 == See Also
 
-* https://docs.mulesoft.com/anypoint-security/[Anypoint Security, role=external, window=blank]
 * https://trust.salesforce.com/en/security/[Salesforce Security, role=external, window=blank]


### PR DESCRIPTION
Valkyrie informed us that https://docs.mulesoft.com/anypoint-security/ is specific to Runtime Fabric, not an overview of the Anypoint platform security architecture. This PR removes the incorrect link, and the second PR will add correct links and info after discussion with PMs.