### PR TITLE
Lightning components

### DIFF
--- a/modules/ROOT/pages/acm-lightning-components.adoc
+++ b/modules/ROOT/pages/acm-lightning-components.adoc
@@ -6,7 +6,7 @@ endif::[]
 
 You design the pages of your API Community Manager (ACM) portal by adding and configuring Lightning components in Community Builder.
 
-These Lightning Components include both the components available in all Salesforce Communities, and the ACM Lightning components only available in ACM.
+These Lightning components include both the Lightning components available in all Salesforce Communities, and the ACM Lightning components only available in ACM.
 
 Each ACM Lightning component has different configuration options and adds different functionality to the portal.
 

--- a/modules/ROOT/pages/configure-acm.adoc
+++ b/modules/ROOT/pages/configure-acm.adoc
@@ -172,7 +172,7 @@ NOTE: Remember to associate the external data source with this authentication pr
 . If you don't have an active session in your Anypoint Platform organization, the *Anypoint Login* page is shown. Log in to the Anypoint Platform to complete the authentication. If you already have an active session, authentication is performed without requiring a login.
 . Verify the Exchange *External Data Sources* *Authentication Status* is *Authenticated*.
 
-After authenticating the External Data Source, provide the credentials of an Anypoint Platform system user with read-only access, for components like the API Console which retrieve data directly from the Anypoint Platform APIs.
+After authenticating the External Data Source, provide the credentials of an Anypoint Platform system user with read-only access, for Lightning components like the API Console which retrieve data directly from the Anypoint Platform APIs.
 
 . Search for *Named Credentials* in the *Quick Find* box and then click *Named Credentials*.
 . Locate the *anypoint.mulesoft* item and then click *Edit*.
@@ -427,11 +427,11 @@ These steps enable guests to register as members in your ACM portal.
 
 ==== Add Self Register Component to Registration Page [[add-self-register-custom-component-to-register-page]]
 
-The self-register component enables guest users to register themselves as members of your community. If you're not using any of the ACM out-of-the-box templates, use these steps to add the ACM-specific self-registration component.
+The self-registration Lightning component enables guest users to register themselves as members of your community. If you're not using any of the ACM out-of-the-box templates, use these steps to add the ACM-specific self-registration Lightning component.
 
 . In the ACM control panel, open *Community Builder* and navigate to the *Register* page in the Pages menu on the top left.
-. Remove the standard *Self Registration* component by clicking the delete icon next to it.
-. Navigate to *Components*, search for *Self Register* and add the component to the page.
+. Remove the standard *Self Registration* Lightning component by clicking the delete icon next to it.
+. Navigate to *Components*, search for *Self Register* and add the Lightning component to the page.
 
 ==== Assign a Profile for Your Community Members [[assign-a-profile-for-your-community-members]]
 
@@ -534,7 +534,7 @@ If you don't configure an approval process, self-registered users will become me
 
 . On the *Approve Registration* page, click *Activate* and confirm.
 . In the ACM control panel, open *Community Builder*, and click *Settings* -> *General*.
-. In Community Builder, navigate to the *Register* page in the pages menu and select the ACM *Self Register* component.
+. In Community Builder, navigate to the *Register* page in the pages menu and select the ACM *Self Register* Lightning component.
 . Verify the *Approved Registration* and set the *Approver Id* with the *User Id* of the user you want to approve the registration requests.
 
 To get the *User Id*:

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -33,7 +33,7 @@ Other ACM features enable your organization to engage with partners and ensure t
 
 == Building Your API Community
 
-Personalize your community look and feel, branding, and site structure by using  https://help.salesforce.com/articleView?id=community_designer_overview.htm&type=5[Community Builder, role=external, window=blank], a drag-and-drop editor that enables you to create and customize the user experience at every level of detail. Community Builder makes it easy to create a tailored experience using pre-existing components and simple clicks, or using the full flexibility of HTML and CSS for precise pixel-perfect experiences.
+Personalize your community look and feel, branding, and site structure by using  https://help.salesforce.com/articleView?id=community_designer_overview.htm&type=5[Community Builder, role=external, window=blank], a drag-and-drop editor that enables you to create and customize the user experience at every level of detail. Community Builder makes it easy to create a tailored experience using pre-existing Lightning components and simple clicks, or using the full flexibility of HTML and CSS for precise pixel-perfect experiences.
 
 == Understand How Your Developers Engage in Your Community
 

--- a/modules/ROOT/pages/publish-apis.adoc
+++ b/modules/ROOT/pages/publish-apis.adoc
@@ -33,7 +33,7 @@ Now set the API information, including visibility, icon, and description.
 . Select *Replace Icon* to set the API version icon.
 . Enter a *Description* for the API version.
 . Leave the *Visibility* as *Admin Only* while you preview the API version as described in the next section.
-. When your API is displayed on the community site in the API carousel component or in an API card, by default it has a single *API Details* button. It can also have an optional *Learn more* button that links to a business content page. In the *Associated "Learn-more" Page* section, select *None* to keep the default, or select *Custom page* and set the *Custom page URL* to a business content page created in Community Builder.
+. When your API is displayed on the community site in the API Carousel component or in an API card, by default it has a single *API Details* button. It can also have an optional *Learn more* button that links to a business content page. In the *Associated "Learn-more" Page* section, select *None* to keep the default, or select *Custom page* and set the *Custom page URL* to a business content page created in Community Builder.
 . Select *Apply*.
 
 == Preview APIs


### PR DESCRIPTION
Per Kim feedback and "Lightning Components Style Guide" at https://docs.google.com/document/d/1UL9a6cVZLu0lajgWOYiD_tHM8qp4_JRzFjCfGLwv01g/edit , standardize on name and capitalization "Lightning components". Fixed one or two other typos and formatting bugs as well.