### PR TITLE
fix typo

### DIFF
--- a/modules/ROOT/pages/create-community.adoc
+++ b/modules/ROOT/pages/create-community.adoc
@@ -355,7 +355,7 @@ Configure a login page:
 . In the API Community Manager control panel, open *Community Administration* and navigate to the *Login & Registration* section in the left panel.
 . Scroll down to the *Registration Page Configuration* section near the bottom of the page.
 .. Select *Allow external users to self-register*.
-.. Select *Community Builder Page* for *Registration Page Type* and click *Register*.
+.. Select *Experience Builder Page* for *Registration Page Type* and click *Register*.
 .. Select *ACM Member Users* in *Profile*.
 .. Select *ACM Registered Users Account* in *Account*.
 . Click *Save*.


### PR DESCRIPTION
In the current UI, the item on the "Registration Page Type" list is "Experience Builder Page" and not "Community Builder Page".