### PR TITLE
Update data-bridge.adoc

### DIFF
--- a/modules/ROOT/pages/data-bridge.adoc
+++ b/modules/ROOT/pages/data-bridge.adoc
@@ -87,6 +87,7 @@ Configure external identity in your Anypoint organization:
 . Set *Issuer* to match the Salesforce account: `salesforce_org_domainname`.
 . Set the *Public Key* to the public key extracted from the `<ds:X509Certificate>` tag in the metadata XML you downloaded.
 . Set *Audience* to match the *Entity Id* you set in the Salesforce account.
+. Select *Identity Provider Only*
 . Select *Enable new non-SSO users*.
 . Click *Save*.
 


### PR DESCRIPTION
Salesforce doesn't sent the "inResponseTo" attribute in the SAML Response when it's initiated by the Service Provider and the authentication fails. It must be set to "Identity Provider only"