### PR TITLE
docs-13092-acm-experience-experience-builder-page-not-default-jh

### DIFF
--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -63,7 +63,7 @@ After the items from *Community profile* through *Account created* are configure
 
 . In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
 . From *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
-. From the search results, select the community name. The account name is the community name + account, for example, MyCommunityName Account.
+. From the search results, select the community name from the list of account names, which are displayed in the format MyCommunityName Account.
 . The *Login and Registration* page shows the community account in the *Accounts* field.
 . From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.
 . Fix the remaining items in the *Member User* list.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -57,7 +57,7 @@ These configuration options work only for the default API Community Manager conf
 * *Account owner role*
 * *Account visibility*
 
-If a new community was created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages will display and not the *Experience Builder Page*.
+If a community was created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages will display and not the *Experience Builder Page*.
 
 After the items from *Community profile* through *Account created* are configured
 , fix the diagnostics for the *Account assigned*:

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -57,7 +57,7 @@ These configuration options work only for the default API Community Manager conf
 * *Account owner role*
 * *Account visibility*
 
-If a community was created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages will display and not the *Experience Builder Page*.
+If a community is created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages displays instead of the *Experience Builder Page*.
 
 After the items from *Community profile* through *Account created* are configured
 , fix the diagnostics for the *Account assigned*:

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -62,7 +62,7 @@ If a community is created but not published, when diagnostics *Fix All* is run f
 After the items from *Community profile* through *Account created* are configured, fix the diagnostics for the *Account assigned*:
 
 . In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
-. From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
+. From *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
 . From the search results, select the community name. The account name is the community name + account, for example, MyCommunityName Account.
 . The *Login and Registration* page shows the community account in the *Accounts* field.
 . From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -59,8 +59,7 @@ These configuration options work only for the default API Community Manager conf
 
 If a community is created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages displays instead of the *Experience Builder Page*.
 
-After the items from *Community profile* through *Account created* are configured
-, fix the diagnostics for the *Account assigned*:
+After the items from *Community profile* through *Account created* are configured, fix the diagnostics for the *Account assigned*:
 
 . In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
 . From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -64,7 +64,7 @@ After the items from *Community profile* through *Account created* are configure
 
 . In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
 . From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
-. From the search results, select the community name.
+. From the search results, select the community name 
 . The *Login and Registration* page shows the community account in the *Accounts* field.
 . From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type*, *Forgot Password*, and *Registration Page Type* fields.
 . Fix the remaining items in the *Member User* list.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -57,14 +57,14 @@ These configuration options work only for the default API Community Manager conf
 * *Account owner role*
 * *Account visibility*
 
-After the items from *Community profile* through *Account created* are correctly configured, assign the Salesforce account manually:
+If a new community was created but not published, when diagnostics *Fix All* is run for the member user, the *Default Page* for the *Login and Registration* pages will display and not the *Experience Builder Page*.
 
-. In the control panel, click *Community Administration* > *Login & Registration*.
-. Scroll to the section *Registration Page Configuration*.
-. Enable *Allow customers and partners to self-register*.
-. Set *Registration Page Type* to *Default Page*.
-. Select your community's member user as the value for *Profile*.
-. Enter your community's Salesforce account name as the value for *Account*.
-. Click *Save*.
-. In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign* to verify that the account is assigned correctly.
-. Fix the remaining items in the list.
+After the items from *Community profile* through *Account created* are configured
+, fix the diagnostics for the *Account assigned*:
+
+. In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
+. From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
+. From the search results, select the community name.
+. The *Login and Registration* page shows the community account in the *Accounts* field.
+. From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type*, *Forgot Password*, and *Registration Page Type* fields.
+. Fix the remaining items in the *Member User* list.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -66,5 +66,5 @@ After the items from *Community profile* through *Account created* are configure
 . From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
 . From the search results, select the community name 
 . The *Login and Registration* page shows the community account in the *Accounts* field.
-. From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type*, *Forgot Password*, and *Registration Page Type* fields.
+. From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.
 . Fix the remaining items in the *Member User* list.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -64,7 +64,7 @@ After the items from *Community profile* through *Account created* are configure
 
 . In the diagnostics page, next to the *Member User* item *Account assigned*, click *Assign*.
 . From the *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
-. From the search results, select the community name 
+. From the search results, select the community name. The account name is the community name + account, for example, MyCommunityName Account.
 . The *Login and Registration* page shows the community account in the *Accounts* field.
 . From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.
 . Fix the remaining items in the *Member User* list.

--- a/modules/ROOT/pages/diagnostics.adoc
+++ b/modules/ROOT/pages/diagnostics.adoc
@@ -65,5 +65,7 @@ After the items from *Community profile* through *Account created* are configure
 . From *Administration Community* > *Accounts*, click the search icon, enter the name of the community, and click *GO!*.
 . From the search results, select the community name from the list of account names, which are displayed in the format MyCommunityName Account.
 . The *Login and Registration* page shows the community account in the *Accounts* field.
-. From the top, right of the community page, click the refresh icon. The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.
+. From the top right of the community page, click the refresh icon.
++
+The *Experience Builder Page* is set for *Login Page Type* and *Registration Page Type* fields.
 . Fix the remaining items in the *Member User* list.


### PR DESCRIPTION
Updated the Diagnostics topic with steps to configure Login & Registration defaults  back to Experience Builder Page.