### PR TITLE
Typos

### DIFF
--- a/modules/ROOT/pages/acm-lightning-components.adoc
+++ b/modules/ROOT/pages/acm-lightning-components.adoc
@@ -219,7 +219,7 @@ You can specify values for the following parameters of the API Documentation Vie
 *Section (Optional)*:: Selects the section to open. If the *Selected page (optional)* setting is empty, the *Section (optional)* setting is ignored.
 *Selected Page (Optional)*:: Selects the page to open.
 
-To link directly to a markdown page in this component, set the URL query paramter `selectedPage` to the exact name of the page. For example, if the page is named "Details", use a URL like this: `/communityapi/a003D000001pQpjQAE/basicapi?selectedPage=Details`. If `selectedPage` is defined both in the Community Builder for this component and in the URL, then the value in Community Builder is used and the value in the URL is ignored.
+To link directly to a markdown page in this component, set the URL query parameter `selectedPage` to the exact name of the page. For example, if the page is named "Details", use a URL like this: `/communityapi/a003D000001pQpjQAE/basicapi?selectedPage=Details`. If `selectedPage` is defined both in the Community Builder for this component and in the URL, then the value in Community Builder is used and the value in the URL is ignored.
 
 [[api-engagement]]
 == API Engagement

--- a/modules/ROOT/pages/api-console.adoc
+++ b/modules/ROOT/pages/api-console.adoc
@@ -66,7 +66,7 @@ If an *API Console* navigation item such as an API endpoint or method has a long
 
 To link directly to an endpoint or type in this component, set the URL query paramters `method`, `path`, or `type`. `method` must be in lower case. `type` is case sensitive. If `method` and `path` are defined and exist in the API definition, then navigation will open there regardless of the `type` parameter. If `method` or `path` is not defined and `type` is defined and exists in the API definition, then navigation will open at the specified `type`. Examples:
 
-* `communityapi/a003D000001pQpjQAE/basicapi?method=get&path=/users/{id}`
+* `communityapi/a003D000001pQpjQAE/basicapi?method=get&path=/users/\{id}`
 * `communityapi/a003D000001pQpjQAE/basicapi?type=Users`
 
 == API Console Documentation

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -161,7 +161,7 @@ Validating and synchronizing the external data source generates duplicate extern
 
 == Missing Feature Error
 
-If you receive a `Missing feaure` error when you install Anypoint API Community Manager, ensure that digital experiences (previously known as _communities_) are enabled in your API Community Manager Salesforce organization.
+If you receive a `Missing feature` error when you install Anypoint API Community Manager, ensure that digital experiences (previously known as _communities_) are enabled in your API Community Manager Salesforce organization.
 
 The error looks similar to this:
 


### PR DESCRIPTION
- minor typo fixes
- escape brackets properly to remove build warning