### PR TITLE
[W-11418808] correct xrefs

### DIFF
--- a/modules/ROOT/nav.adoc
+++ b/modules/ROOT/nav.adoc
@@ -43,7 +43,7 @@
 ** xref:troubleshooting-broken-images-on-documentation-pages.adoc[Broken Images on Documentation Pages]
 ** xref:troubleshooting-changes-to-apis-are-not-displaying.adoc[Changes to APIs Are Not Displaying]
 ** xref:troubleshooting-console-mocking-service-not-loading.adoc[Console Mocking Service Not Loading]
-** xref:troubleshooting-duplicate-external-objects.adoc[Duplicate External Objects]
+** xref:troubleshooting-duplicated-external-objects.adoc[Duplicate External Objects]
 ** xref:troubleshooting-empty-login-page.adoc[Empty Login Page]
 ** xref:troubleshooting-error-when-creating-new-community-from-template.adoc[Error When Creating New Community from Template]
 ** xref:troubleshooting-incorrect-or-missing-data-for-one-api-version.adoc[Incorrect or Missing Data for One API Version]

--- a/modules/ROOT/pages/troubleshooting.adoc
+++ b/modules/ROOT/pages/troubleshooting.adoc
@@ -10,7 +10,7 @@ If you encounter errors while you are using API Community Manager, refer to thes
 * xref:troubleshooting-broken-images-on-documentation-pages.adoc[Broken Images on Documentation Pages]
 * xref:troubleshooting-changes-to-apis-are-not-displaying.adoc[Changes to APIs Are Not Displaying]
 * xref:troubleshooting-console-mocking-service-not-loading.adoc[Console Mocking Service Not Loading]
-* xref:troubleshooting-duplicate-external-objects.adoc[Duplicate External Objects]
+* xref:troubleshooting-duplicated-external-objects.adoc[Duplicate External Objects]
 * xref:troubleshooting-empty-login-page.adoc[Empty Login Page]
 * xref:troubleshooting-error-when-creating-new-community-from-template.adoc[Error When Creating New Community from Template]
 * xref:troubleshooting-incorrect-or-missing-data-for-one-api-version.adoc[Incorrect or Missing Data for One API Version]


### PR DESCRIPTION
ref: W-11418808

fix the xrefs to match the name of the adoc file. An alternative fix would be to change the name of the adoc file and revert the xrefs. Please advise 😄 

# Writer's Quality Checklist

Before merging your PR, did you:

- [ ] Run spell checker
- [ ] Run link checker to check for broken xrefs
- [ ] Check for orphan files
- [ ] Perform a local build and do a final visual check of your content, including checking for:
  - Broken images
  - Dead links
  - Correct rendering of partials if they are used in your content
  - Formatting issues, such as:
    - Misnumbered ordered lists (steps) or incorrectly nested unordered lists
    - Messed up tables
    - Proper indentation
    - Correct header levels
- [ ] Receive final review and signoff from:
  - Technical SME
  - Product Manager
  - Editor or peer reviewer
  - Reporter, if this content is in response to a reported issue (internal or external feedback)
- [ ] If applicable, verify that the software actually got released