### PR TITLE
[W-20976280] fix help.salesforce.com links

### DIFF
--- a/modules/ROOT/pages/branded-emails.adoc
+++ b/modules/ROOT/pages/branded-emails.adoc
@@ -11,7 +11,7 @@ instead, use these steps.
 
 == Disable Standard Email Security
 
-Branded emails require disabling Salesforce's standard configuration for Sender Policy Framework (SPF) for email. For more information about this feature, see the Salesforce Help article https://help.salesforce.com/s/articleView?id=sf.emailadmin_enable_email_security_compliance.htm&type=5[Enable Email Security Compliance, role=external, window=blank].
+Branded emails require disabling Salesforce's standard configuration for Sender Policy Framework (SPF) for email. For more information about this feature, see the Salesforce Help article https://help.salesforce.com/s/articleView?id=sales.emailadmin_enable_email_security_compliance.htm&type=5[Enable Email Security Compliance, role=external, window=blank].
 
 To disable the standard configuration, open *Setup* > *Deliverability* > *Email Security Compliance* and ensure the option *Enable compliance with standard email security mechanisms* is not selected.
 

--- a/modules/ROOT/pages/create-community.adoc
+++ b/modules/ROOT/pages/create-community.adoc
@@ -10,7 +10,7 @@ You can create any number of sites. All sites are in the same Salesforce organiz
 
 Installing, updating, or configuring API Community Manager must be done by a user account with the *System Administrator* profile in the API Community Manager Salesforce organization.
 
-If you are not familiar with Experience Cloud, refer to the https://help.salesforce.com/articleView?id=sf.networks_resources.htm&type=5[Experience Cloud Overview, role=external, window=_blank].
+If you are not familiar with Experience Cloud, refer to the https://help.salesforce.com/s/articleView?id=experience.networks_resources.htm&type=5[Experience Cloud Overview, role=external, window=_blank].
 
 == Create a New Community
 

--- a/modules/ROOT/pages/visibility.adoc
+++ b/modules/ROOT/pages/visibility.adoc
@@ -8,7 +8,7 @@ Anypoint API Community Manager uses visibility rules to make APIs visible to sel
 
 For example, your community could have a Payment API and a Trade API visible to the financial developers team of three users, and have an Order Submission API visible to the retail developers team of two other users.
 
-API visibility rules use the Salesforce object CommunityApi to represent each API published in your community, and Salesforce https://help.salesforce.com/articleView?id=sf.user_groups.htm&type=5[Public Groups, role=external, window=blank] and https://help.salesforce.com/articleView?id=sf.security_about_sharing_rules.htm&type=5[Sharing Rules, role=external, window=blank] to provide a flexible permissions model.
+API visibility rules use the Salesforce object CommunityApi to represent each API published in your community, and Salesforce https://help.salesforce.com/s/articleView?id=platform.user_groups.htm&type=5[Public Groups, role=external, window=blank] and https://help.salesforce.com/s/articleView?id=platform.security_about_sharing_rules.htm&type=5[Sharing Rules, role=external, window=blank] to provide a flexible permissions model.
 
 == Visibility Setup
 
@@ -106,6 +106,6 @@ To make an API visible to a member group:
 
 Assign users to member groups automatically with the option that best suits your needs:
 
-* For simple automation such as adding each new user to a default member group, use Salesforce https://help.salesforce.com/articleView?id=sf.process_overview.htm&type=5[Process Builder, role=external, window=blank].
+* For simple automation such as adding each new user to a default member group, use Salesforce https://help.salesforce.com/s/articleView?id=platform.process_overview.htm&type=5[Process Builder, role=external, window=blank].
 * For complex automation by writing business rules for group assignment directly in APEX code, use https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_triggers.htm[APEX triggers, role=external, window=blank].
 * For complex automation by using declarative group assignment, use Salesforce https://help.salesforce.com/articleView?id=sf.flow.htm&type=5[Flows, role=external, window=blank].


### PR DESCRIPTION
## Summary
Applied text replacement for Salesforce documentation URL updates in docs-api-community-manager.

## Changes
- Replaced URLs in 3 file(s)

## Files Changed
- ./modules/ROOT/pages/branded-emails.adoc
- ./modules/ROOT/pages/create-community.adoc
- ./modules/ROOT/pages/visibility.adoc (multiple replacements)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Update
- [ ] Refactor
- [ ] Documentation

## Related
- GUS Work Item: W-20976280